### PR TITLE
Migrate to event-based build dependency resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0) and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-06-09
+
+### Changed
+
+- Replaced polling-based dependency checks with an event-driven callback system  
+  This improves performance and responsiveness by allowing builds to immediately react to dependency changes instead of
+  waiting for periodic checks.
+
 ## [1.0.0] - 2025-06-07
 
 Initial release
 
-[Unreleased]: https://github.com/jhae-de/tsup-sequential-build-plugin/compare/v1.0.0...main
+[Unreleased]: https://github.com/jhae-de/tsup-sequential-build-plugin/compare/v1.1.0...main
+[1.1.0]: https://github.com/jhae-de/tsup-sequential-build-plugin/releases/tag/v1.1.0
 [1.0.0]: https://github.com/jhae-de/tsup-sequential-build-plugin/releases/tag/v1.0.0

--- a/tests/build-state-manager.class.test.ts
+++ b/tests/build-state-manager.class.test.ts
@@ -30,47 +30,47 @@ describe('BuildStateManager', (): void => {
 
   describe('State modification', (): void => {
     it('allows registering a build identifier', (): void => {
-      buildStateManager.registerBuild('_build_identifier_');
+      buildStateManager.registerBuild('build-identifier');
 
-      expect(buildStateManager.isBuildRegistered('_build_identifier_')).toBe(true);
+      expect(buildStateManager.isBuildRegistered('build-identifier')).toBe(true);
       expect(buildStateManager.hasRegisteredBuilds()).toBe(true);
     });
 
     it('allows marking a build as completed', (): void => {
-      buildStateManager.registerBuild('_build_identifier_');
-      buildStateManager.completeBuild('_build_identifier_');
+      buildStateManager.registerBuild('build-identifier');
+      buildStateManager.completeBuild('build-identifier');
 
-      expect(buildStateManager.isBuildCompleted('_build_identifier_')).toBe(true);
+      expect(buildStateManager.isBuildCompleted('build-identifier')).toBe(true);
       expect(buildStateManager.hasCompletedBuilds()).toBe(true);
     });
 
     it('returns true when registering a new build', (): void => {
-      expect(buildStateManager.registerBuild('_build_identifier_')).toBe(true);
+      expect(buildStateManager.registerBuild('build-identifier')).toBe(true);
     });
 
     it('returns false when registering an already registered build', (): void => {
-      buildStateManager.registerBuild('_build_identifier_');
+      buildStateManager.registerBuild('build-identifier');
 
-      expect(buildStateManager.registerBuild('_build_identifier_')).toBe(false);
+      expect(buildStateManager.registerBuild('build-identifier')).toBe(false);
     });
 
     it('throws an error when completing an unregistered build', (): void => {
-      expect((): void => buildStateManager.completeBuild('_build_identifier_')).toThrow(
-        'Build _build_identifier_ not registered',
+      expect((): void => buildStateManager.completeBuild('build-identifier')).toThrow(
+        'Build build-identifier not registered',
       );
     });
 
     it('does not duplicate build identifiers in registeredBuilds', (): void => {
-      buildStateManager.registerBuild('_build_identifier_');
-      buildStateManager.registerBuild('_build_identifier_');
+      buildStateManager.registerBuild('build-identifier');
+      buildStateManager.registerBuild('build-identifier');
 
       expect(buildStateManager.getRegisteredBuilds().length).toBe(1);
     });
 
     it('does not duplicate build identifiers in completedBuilds', (): void => {
-      buildStateManager.registerBuild('_build_identifier_');
-      buildStateManager.completeBuild('_build_identifier_');
-      buildStateManager.completeBuild('_build_identifier_');
+      buildStateManager.registerBuild('build-identifier');
+      buildStateManager.completeBuild('build-identifier');
+      buildStateManager.completeBuild('build-identifier');
 
       expect(buildStateManager.getCompletedBuilds().length).toBe(1);
     });
@@ -78,108 +78,223 @@ describe('BuildStateManager', (): void => {
 
   describe('Individual build state checks', (): void => {
     it('correctly identifies registered builds', (): void => {
-      buildStateManager.registerBuild('_build_identifier_1_');
+      buildStateManager.registerBuild('build-identifier-1');
 
-      expect(buildStateManager.isBuildRegistered('_build_identifier_1_')).toBe(true);
-      expect(buildStateManager.isBuildRegistered('_build_identifier_2_')).toBe(false);
+      expect(buildStateManager.isBuildRegistered('build-identifier-1')).toBe(true);
+      expect(buildStateManager.isBuildRegistered('build-identifier-2')).toBe(false);
     });
 
     it('correctly identifies completed builds', (): void => {
-      buildStateManager.registerBuild('_build_identifier_1_');
-      buildStateManager.completeBuild('_build_identifier_1_');
+      buildStateManager.registerBuild('build-identifier-1');
+      buildStateManager.completeBuild('build-identifier-1');
 
-      expect(buildStateManager.isBuildCompleted('_build_identifier_1_')).toBe(true);
-      expect(buildStateManager.isBuildCompleted('_build_identifier_2_')).toBe(false);
+      expect(buildStateManager.isBuildCompleted('build-identifier-1')).toBe(true);
+      expect(buildStateManager.isBuildCompleted('build-identifier-2')).toBe(false);
     });
 
     it('correctly identifies pending builds', (): void => {
-      buildStateManager.registerBuild('_build_identifier_1_');
-      buildStateManager.registerBuild('_build_identifier_2_');
-      buildStateManager.completeBuild('_build_identifier_2_');
+      buildStateManager.registerBuild('build-identifier-1');
+      buildStateManager.registerBuild('build-identifier-2');
+      buildStateManager.completeBuild('build-identifier-2');
 
-      expect(buildStateManager.isBuildPending('_build_identifier_1_')).toBe(true);
-      expect(buildStateManager.isBuildPending('_build_identifier_2_')).toBe(false);
-      expect(buildStateManager.isBuildPending('_build_identifier_3_')).toBe(false);
+      expect(buildStateManager.isBuildPending('build-identifier-1')).toBe(true);
+      expect(buildStateManager.isBuildPending('build-identifier-2')).toBe(false);
+      expect(buildStateManager.isBuildPending('build-identifier-3')).toBe(false);
     });
   });
 
   describe('Collection state checks', (): void => {
+    it('clears all state when clear() is called', (): void => {
+      buildStateManager.registerBuild('build-identifier-1');
+      buildStateManager.registerBuild('build-identifier-2');
+      buildStateManager.completeBuild('build-identifier-1');
+
+      const callbackMock: jest.Mock = jest.fn();
+      buildStateManager.onBuildCompleted(callbackMock);
+
+      buildStateManager.clear();
+
+      expect(buildStateManager.hasRegisteredBuilds()).toBe(false);
+      expect(buildStateManager.hasCompletedBuilds()).toBe(false);
+      expect(buildStateManager.hasPendingBuilds()).toBe(false);
+
+      buildStateManager.registerBuild('build-identifier');
+      buildStateManager.completeBuild('build-identifier');
+
+      expect(callbackMock).not.toHaveBeenCalled();
+    });
+
     it('correctly checks for registered builds', (): void => {
       expect(buildStateManager.hasRegisteredBuilds()).toBe(false);
 
-      buildStateManager.registerBuild('_build_identifier_');
+      buildStateManager.registerBuild('build-identifier');
       expect(buildStateManager.hasRegisteredBuilds()).toBe(true);
-
-      buildStateManager.clear();
-      expect(buildStateManager.hasRegisteredBuilds()).toBe(false);
     });
 
     it('correctly checks for completed builds', (): void => {
       expect(buildStateManager.hasCompletedBuilds()).toBe(false);
 
-      buildStateManager.registerBuild('_build_identifier_');
-      buildStateManager.completeBuild('_build_identifier_');
+      buildStateManager.registerBuild('build-identifier');
+      buildStateManager.completeBuild('build-identifier');
       expect(buildStateManager.hasCompletedBuilds()).toBe(true);
-
-      buildStateManager.clear();
-      expect(buildStateManager.hasCompletedBuilds()).toBe(false);
     });
 
     it('correctly checks for pending builds', (): void => {
       expect(buildStateManager.hasPendingBuilds()).toBe(false);
 
-      buildStateManager.registerBuild('_build_identifier_1_');
+      buildStateManager.registerBuild('build-identifier-1');
       expect(buildStateManager.hasPendingBuilds()).toBe(true);
 
-      buildStateManager.completeBuild('_build_identifier_1_');
+      buildStateManager.completeBuild('build-identifier-1');
       expect(buildStateManager.hasPendingBuilds()).toBe(false);
 
-      buildStateManager.registerBuild('_build_identifier_2_');
-      buildStateManager.registerBuild('_build_identifier_3_');
-      buildStateManager.completeBuild('_build_identifier_2_');
+      buildStateManager.registerBuild('build-identifier-2');
+      buildStateManager.registerBuild('build-identifier-3');
+      buildStateManager.completeBuild('build-identifier-2');
       expect(buildStateManager.hasPendingBuilds()).toBe(true);
 
-      buildStateManager.completeBuild('_build_identifier_3_');
+      buildStateManager.completeBuild('build-identifier-3');
       expect(buildStateManager.hasPendingBuilds()).toBe(false);
     });
   });
 
   describe('Collection data retrieval', (): void => {
     it('returns all registered builds correctly', (): void => {
-      buildStateManager.registerBuild('_build_identifier_1_');
-      buildStateManager.registerBuild('_build_identifier_2_');
+      buildStateManager.registerBuild('build-identifier-1');
+      buildStateManager.registerBuild('build-identifier-2');
 
-      const registeredBuilds: string[] = buildStateManager.getRegisteredBuilds();
+      const registeredBuilds: readonly string[] = buildStateManager.getRegisteredBuilds();
 
       expect(registeredBuilds.length).toBe(2);
-      expect(registeredBuilds).toContain('_build_identifier_1_');
-      expect(registeredBuilds).toContain('_build_identifier_2_');
+      expect(registeredBuilds).toContain('build-identifier-1');
+      expect(registeredBuilds).toContain('build-identifier-2');
     });
 
     it('returns all completed builds correctly', (): void => {
-      buildStateManager.registerBuild('_build_identifier_1_');
-      buildStateManager.registerBuild('_build_identifier_2_');
-      buildStateManager.completeBuild('_build_identifier_1_');
+      buildStateManager.registerBuild('build-identifier-1');
+      buildStateManager.registerBuild('build-identifier-2');
+      buildStateManager.completeBuild('build-identifier-1');
 
-      const completedBuilds: string[] = buildStateManager.getCompletedBuilds();
+      const completedBuilds: readonly string[] = buildStateManager.getCompletedBuilds();
 
       expect(completedBuilds.length).toBe(1);
-      expect(completedBuilds).toContain('_build_identifier_1_');
-      expect(completedBuilds).not.toContain('_build_identifier_2_');
+      expect(completedBuilds).toContain('build-identifier-1');
+      expect(completedBuilds).not.toContain('build-identifier-2');
     });
 
     it('returns pending builds correctly', (): void => {
-      buildStateManager.registerBuild('_build_identifier_1_');
-      buildStateManager.registerBuild('_build_identifier_2_');
-      buildStateManager.registerBuild('_build_identifier_3_');
-      buildStateManager.completeBuild('_build_identifier_2_');
+      buildStateManager.registerBuild('build-identifier-1');
+      buildStateManager.registerBuild('build-identifier-2');
+      buildStateManager.registerBuild('build-identifier-3');
+      buildStateManager.completeBuild('build-identifier-2');
 
-      const pendingBuilds: string[] = buildStateManager.getPendingBuilds();
+      const pendingBuilds: readonly string[] = buildStateManager.getPendingBuilds();
 
       expect(pendingBuilds.length).toBe(2);
-      expect(pendingBuilds).toContain('_build_identifier_1_');
-      expect(pendingBuilds).not.toContain('_build_identifier_2_');
-      expect(pendingBuilds).toContain('_build_identifier_3_');
+      expect(pendingBuilds).toContain('build-identifier-1');
+      expect(pendingBuilds).not.toContain('build-identifier-2');
+      expect(pendingBuilds).toContain('build-identifier-3');
+    });
+
+    it('returns immutable collections that cannot be modified', (): void => {
+      buildStateManager.registerBuild('build-identifier-1');
+      buildStateManager.registerBuild('build-identifier-2');
+      buildStateManager.completeBuild('build-identifier-1');
+
+      const registeredBuilds: readonly string[] = buildStateManager.getRegisteredBuilds();
+      const completedBuilds: readonly string[] = buildStateManager.getCompletedBuilds();
+      const pendingBuilds: readonly string[] = buildStateManager.getPendingBuilds();
+
+      (registeredBuilds as string[]).push('build-identifier-3');
+      (completedBuilds as string[]).pop();
+      (pendingBuilds as string[])[0] = 'modified-identifier';
+
+      expect(buildStateManager.getRegisteredBuilds().length).toBe(2);
+      expect(buildStateManager.isBuildRegistered('build-identifier-3')).toBe(false);
+      expect(buildStateManager.getCompletedBuilds().length).toBe(1);
+      expect(buildStateManager.isBuildCompleted('build-identifier-1')).toBe(true);
+      expect(buildStateManager.getPendingBuilds()[0]).toBe('build-identifier-2');
+    });
+  });
+
+  describe('Build completion callbacks', (): void => {
+    it('notifies registered callbacks when a build is completed', (): void => {
+      const callbackMock: jest.Mock = jest.fn();
+      buildStateManager.onBuildCompleted(callbackMock);
+
+      buildStateManager.registerBuild('build-identifier');
+      buildStateManager.completeBuild('build-identifier');
+
+      expect(callbackMock).toHaveBeenCalledTimes(1);
+      expect(callbackMock).toHaveBeenCalledWith('build-identifier');
+    });
+
+    it('passes the correct build identifier to callbacks', (): void => {
+      const callbackMock: jest.Mock = jest.fn();
+      buildStateManager.onBuildCompleted(callbackMock);
+
+      buildStateManager.registerBuild('build-identifier-1');
+      buildStateManager.registerBuild('build-identifier-2');
+
+      buildStateManager.completeBuild('build-identifier-1');
+      expect(callbackMock).toHaveBeenCalledWith('build-identifier-1');
+
+      buildStateManager.completeBuild('build-identifier-2');
+      expect(callbackMock).toHaveBeenCalledWith('build-identifier-2');
+    });
+
+    it('allows unregistering callbacks with the returned function', (): void => {
+      const callbackMock: jest.Mock = jest.fn();
+      const unregister: () => void = buildStateManager.onBuildCompleted(callbackMock);
+
+      unregister();
+
+      buildStateManager.registerBuild('build-identifier');
+      buildStateManager.completeBuild('build-identifier');
+
+      expect(callbackMock).not.toHaveBeenCalled();
+    });
+
+    it('only calls callback once for already completed builds', (): void => {
+      const callbackMock: jest.Mock = jest.fn();
+      buildStateManager.onBuildCompleted(callbackMock);
+
+      buildStateManager.registerBuild('build-identifier');
+      buildStateManager.completeBuild('build-identifier');
+      buildStateManager.completeBuild('build-identifier');
+
+      expect(callbackMock).toHaveBeenCalledTimes(1);
+      expect(callbackMock).toHaveBeenCalledWith('build-identifier');
+    });
+
+    it('calls multiple registered callbacks when a build completes', (): void => {
+      const callbackMock1: jest.Mock = jest.fn();
+      const callbackMock2: jest.Mock = jest.fn();
+
+      buildStateManager.onBuildCompleted(callbackMock1);
+      buildStateManager.onBuildCompleted(callbackMock2);
+
+      buildStateManager.registerBuild('build-identifier');
+      buildStateManager.completeBuild('build-identifier');
+
+      expect(callbackMock1).toHaveBeenCalledTimes(1);
+      expect(callbackMock1).toHaveBeenCalledWith('build-identifier');
+      expect(callbackMock2).toHaveBeenCalledTimes(1);
+      expect(callbackMock2).toHaveBeenCalledWith('build-identifier');
+    });
+
+    it('does not notify callbacks about builds completed before the callback was registered', (): void => {
+      buildStateManager.registerBuild('build-identifier-1');
+      buildStateManager.completeBuild('build-identifier-1');
+
+      const callbackMock: jest.Mock = jest.fn();
+      buildStateManager.onBuildCompleted(callbackMock);
+
+      buildStateManager.registerBuild('build-identifier-2');
+      buildStateManager.completeBuild('build-identifier-2');
+
+      expect(callbackMock).toHaveBeenCalledTimes(1);
+      expect(callbackMock).toHaveBeenCalledWith('build-identifier-2');
     });
   });
 });


### PR DESCRIPTION
This pull request introduces an event-driven callback system to replace polling-based dependency checks, improving performance and responsiveness in the build process. The most significant changes include adding a callback mechanism for build completions, updating the `BuildStateManager` to support this functionality, and refactoring the build process to leverage the new event-driven approach.

### Event-driven callback system

* **Added callback mechanism for build completions**
  - Introduced `buildCompletionCallbacks` in `BuildStateManager` to store callbacks triggered when a build is completed.
  - Added `onBuildCompleted` method to register callbacks and return an unregister function for cleanup.
  - Modified `markBuildAsCompleted` to trigger registered callbacks when a build is completed.

* **Refactored build process to use event-driven approach**
  - Replaced polling logic with callback-based dependency resolution in the `createSequentialBuildPlugin` function. This ensures builds wait for dependencies to complete without periodic checks.

### General improvements

* Enhanced immutability in `BuildStateManager` by changing return types of `getRegisteredBuilds`, `getCompletedBuilds`, and `getPendingBuilds` to readonly arrays for better immutability.